### PR TITLE
Clarified territorial application

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ If you want your license to be irrevocable, perpetual, transferable, sub-licence
 
 Simple.
 
-If you want your licence to be **non-transferable** and **exclusive** (and expansive in every other way), you just need to write:
+If you want your licence to be **non-transferable**, **exclusive** and applicable **only in Australia** (but expansive in every other way), you just need to write:
 
-> Provider grants an exclusive, non-transferable <a href="" target="_blank">licence</a> to the Customer to deal with the Code for any purpose.
+> Provider grants an exclusive, non-transferable <a href="" target="_blank">licence</a> to the Customer to deal with the Code in Australia for any purpose.
 
 ### Parameters
 


### PR DESCRIPTION
I think people may be confused by what 'global' means. Territorial limitation is usually an important part of the licence so thought it was worth adding to the example Also it is likely to be worded differently to the other limitations. Instead of being part of a list in the middle of the clause "non-transferrable, exclusive etc.", it is something you add at the end of the clause: "in Australia"/"in the Territory"/"in Germany and France". Query also whether it might be worth adding "in Australia only" and encouraging users to add the word "only"?
